### PR TITLE
dockerfile clone magpie 0.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,7 +56,7 @@ ENV DAEMON_OPTS --nodaemon
 WORKDIR /
 RUN git clone https://github.com/ouranosinc/magpie && \
     cd magpie && \
-    git checkout service-api-perms && \
+    git checkout 0.6.0 && \
     cd .. && \
     ./opt/conda/envs/twitcher/bin/pip install -r magpie/requirements.txt && \
     ./opt/conda/envs/twitcher/bin/pip install ./magpie


### PR DESCRIPTION
will be tagged `pavics-0.3.7`