### PR TITLE
db-factory setting + jobstore-factory

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -50,6 +50,7 @@ log-level = WARN
 hostname = localhost
 https-port = 5000
 twitcher-url = https://${:hostname}:${:https-port}
+db-factory = mongodb
 mongodb-host = localhost
 mongodb-port = 27027
 mongodb-dbname = twitcher_db

--- a/custom.cfg.example
+++ b/custom.cfg.example
@@ -10,6 +10,11 @@ hostname = localhost
 https-port = 5000
 log-level = WARN
 
+db-factory = mongodb
+mongodb-host = localhost
+mongodb-port = 27017
+mongodb-dbname = twitcher_db
+
 wps-restapi = true
 adapter = package.path.to.AdapterImpl
 restapi-path = /

--- a/templates/twitcher.ini
+++ b/templates/twitcher.ini
@@ -22,6 +22,7 @@ twitcher.url = ${settings:twitcher-url}
 twitcher.rcpinterface = ${settings:rpcinterface}
 twitcher.username = ${settings:username}
 twitcher.password = ${settings:password}
+twitcher.db_factory = ${settings:db-factory}
 twitcher.ows_security = ${settings:ows-security}
 twitcher.ows_proxy = ${settings:ows-proxy}
 twitcher.ows_proxy_delegate = ${settings:ows-proxy-delegate}

--- a/twitcher/adapter/__init__.py
+++ b/twitcher/adapter/__init__.py
@@ -35,11 +35,19 @@ def adapter_factory(settings):
     return DefaultAdapter()
 
 
-def servicestore_factory(registry, database=None):
+def servicestore_factory(registry):
     try:
-        return adapter_factory(registry.settings).servicestore_factory(registry, database)
+        return adapter_factory(registry.settings).servicestore_factory(registry)
     except Exception as e:
         LOGGER.error('Adapter raised an exception while getting servicestore_factory : {!r}'.format(e))
+        raise
+
+
+def jobstore_factory(registry):
+    try:
+        return adapter_factory(registry.settings).jobstore_factory(registry)
+    except Exception as e:
+        LOGGER.error('Adapter raised an exception while getting jobstore_factory : {!r}'.format(e))
         raise
 
 

--- a/twitcher/adapter/base.py
+++ b/twitcher/adapter/base.py
@@ -9,9 +9,15 @@ class AdapterInterface(object):
         """
         raise NotImplementedError
 
-    def servicestore_factory(self, registry, database=None):
+    def servicestore_factory(self, registry):
         """
         Returns the 'servicestore' implementation of the adapter.
+        """
+        raise NotImplementedError
+
+    def jobstore_factory(self, registry):
+        """
+        Returns the 'jobstore' implementation of the adapter.
         """
         raise NotImplementedError
 

--- a/twitcher/adapter/default.py
+++ b/twitcher/adapter/default.py
@@ -7,10 +7,15 @@ class DefaultAdapter(AdapterInterface):
         from twitcher import __version__
         return {"name": "default", "version": str(__version__)}
 
-    def servicestore_factory(self, registry, database=None):
+    def servicestore_factory(self, registry):
         __doc__ = super(DefaultAdapter, self).__doc__
         from twitcher.store import servicestore_defaultfactory
-        return servicestore_defaultfactory(registry, database)
+        return servicestore_defaultfactory(registry)
+
+    def jobstore_factory(self, registry):
+        __doc__ = super(DefaultAdapter, self).__doc__
+        from twitcher.store import jobstore_defaultfactory
+        return jobstore_defaultfactory(registry)
 
     def owssecurity_factory(self, registry):
         __doc__ = super(DefaultAdapter, self).__doc__

--- a/twitcher/datatype.py
+++ b/twitcher/datatype.py
@@ -3,7 +3,7 @@ Definitions of types used by tokens.
 """
 
 import time
-
+import uuid
 from twitcher.utils import now_secs
 from twitcher.exceptions import AccessTokenNotFound
 
@@ -54,6 +54,110 @@ class Service(dict):
 
     def __str__(self):
         return self.name
+
+    def __repr__(self):
+        cls = type(self)
+        repr_ = dict.__repr__(self)
+        return '{0}.{1}({2})'.format(cls.__module__, cls.__name__, repr_)
+
+
+class Job(dict):
+    """
+    Dictionary that contains OWS service jobs. It always has ``'task_id'`` and ``identifier`` keys.
+    """
+    def __init__(self, *args, **kwargs):
+        super(Job, self).__init__(*args, **kwargs)
+        if 'task_id' not in self:
+            raise TypeError("'task_id' is required")
+        self['identifier'] = uuid.uuid4().get_hex()
+
+    @property
+    def task_id(self):
+        return self['task_id']
+
+    @property
+    def identifier(self):
+        return self['identifier']
+
+    @property
+    def service(self):
+        return self.get('service', None)
+
+    @property
+    def process(self):
+        return self.get('process', None)
+
+    @property
+    def user_id(self):
+        return self.get('user_id', None)
+
+    @property
+    def status(self):
+        return self.get('status', 'unknown')
+
+    @property
+    def status_message(self):
+        return self.get('status_message', '')
+
+    @property
+    def status_location(self):
+        return self.get('status_message', None)
+
+    @property
+    def is_workflow(self):
+        return self.get('is_workflow', False)
+
+    @property
+    def created(self):
+        return self.get('created', None)
+
+    @property
+    def finished(self):
+        return self.get('finished', None)
+
+    @property
+    def duration(self):
+        return self.get('duration', None)
+
+    @property
+    def logs(self):
+        return self.get('logs', list())
+
+    @property
+    def tags(self):
+        return self.get('tags', list())
+
+    @property
+    def request(self):
+        return self.get('request', list())
+
+    @property
+    def response(self):
+        return self.get('response', list())
+
+    @property
+    def params(self):
+        return {
+            'task_id': self.task_id,
+            'identifier': self.identifier,
+            'service': self.service,
+            'process': self.process,
+            'user_id': self.user_id,
+            'status': self.status,
+            'status_message': self.status_message,
+            'status_location': self.status_location,
+            'is_workflow': self.is_workflow,
+            'created': self.created,
+            'finished': self.finished,
+            'duration': self.duration,
+            'logs': self.logs,
+            'tags': self.tags,
+            'request': self.request,
+            'response': self.response,
+        }
+
+    def __str__(self):
+        return 'Job <{}>'.format(self.task_id)
 
     def __repr__(self):
         cls = type(self)

--- a/twitcher/exceptions.py
+++ b/twitcher/exceptions.py
@@ -25,3 +25,19 @@ class ServiceRegistrationError(Exception):
     storage backend by an instance of :class:`twitcher.store.ServiceStore`.
     """
     pass
+
+
+class JobNotFound(Exception):
+    """
+    Error indicating that an job could not be read from the
+    storage backend by an instance of :class:`twitcher.store.JobStore`.
+    """
+    pass
+
+
+class JobRegistrationError(Exception):
+    """
+    Error indicating that an job could not be registered in the
+    storage backend by an instance of :class:`twitcher.store.JobStore`.
+    """
+    pass

--- a/twitcher/store/__init__.py
+++ b/twitcher/store/__init__.py
@@ -3,44 +3,73 @@ Factories to create storage backends.
 """
 
 # Factories
-from twitcher.db import mongodb as _mongodb
+from twitcher.db import mongodb as mongodb_factory
 # Interfaces
-from twitcher.store.base import AccessTokenStore
-from twitcher.store.memory import MemoryTokenStore
-from twitcher.store.mongodb import MongodbTokenStore
+from twitcher.store.memory import MemoryTokenStore, MemoryServiceStore, MemoryJobStore
+from twitcher.store.mongodb import MongodbTokenStore, MongodbServiceStore, MongodbJobStore
 
-def tokenstore_factory(registry, database=None):
+# TODO: add any other db factory configuration here as needed
+DB_MONGODB = 'mongodb'
+DB_MEMORY = 'memory'
+SUPPORTED_DB_FACTORIES = frozenset([DB_MONGODB, DB_MEMORY])
+
+
+def get_db_factory(registry):
+    """
+    Obtains `twitcher.db_factory` from `config.registry.settings` and validates it.
+    :returns: A string representing the configured database factory. (default: 'mongodb')
+    """
+    settings = registry.settings
+    db_factory = settings.get('twitcher.db_factory', DB_MONGODB)
+    if db_factory in SUPPORTED_DB_FACTORIES:
+        return db_factory
+    raise NotImplementedError("Unknown settings `twitcher.db_factory` == `{}`.".format(str(db_factory)))
+
+
+def tokenstore_factory(registry):
     """
     Creates a token store with the interface of :class:`twitcher.store.AccessTokenStore`.
     By default the mongodb implementation will be used.
 
-    :param database: A string with the store implementation name: "mongodb" or "memory".
+    :param registry: Application registry defining `twitcher.db_factory`.
     :return: An instance of :class:`twitcher.store.AccessTokenStore`.
     """
-    database = database or 'mongodb'
-    if database == 'mongodb':
-        db = _mongodb(registry)
+    database = get_db_factory(registry)
+    if database == DB_MONGODB:
+        db = mongodb_factory(registry)
         store = MongodbTokenStore(db.tokens)
     else:
         store = MemoryTokenStore()
     return store
 
 
-from twitcher.store.mongodb import MongodbServiceStore
-from twitcher.store.memory import MemoryServiceStore
-
-
-def servicestore_defaultfactory(registry, database=None):
+def servicestore_defaultfactory(registry):
     """
     Creates a service store with the interface of :class:`twitcher.store.ServiceStore`.
-    By default the mongodb implementation will be used.
 
+    :param registry: Application registry defining `twitcher.db_factory`.
     :return: An instance of :class:`twitcher.store.ServiceStore`.
     """
-    database = database or 'mongodb'
-    if database == 'mongodb':
-        db = _mongodb(registry)
+    database = get_db_factory(registry)
+    if database == DB_MONGODB:
+        db = mongodb_factory(registry)
         store = MongodbServiceStore(collection=db.services)
     else:
         store = MemoryServiceStore()
+    return store
+
+
+def jobstore_defaultfactory(registry):
+    """
+    Creates a job store with the interface of :class:`twitcher.store.JobStore`.
+
+    :param registry: Application registry defining `twitcher.db_factory`.
+    :return: An instance of :class:`twitcher.store.JobStore`.
+    """
+    database = get_db_factory(registry)
+    if database == DB_MONGODB:
+        db = mongodb_factory(registry)
+        store = MongodbJobStore(collection=db.jobs)
+    else:
+        store = MemoryJobStore()
     return store

--- a/twitcher/store/base.py
+++ b/twitcher/store/base.py
@@ -73,7 +73,7 @@ class ServiceStore(object):
         """
         Get service for given ``name`` from storage.
 
-        :param token: A string containing the service name.
+        :param name: A string containing the service name.
         :return: An instance of :class:`twitcher.datatype.Service`.
         """
         raise NotImplementedError
@@ -90,5 +90,56 @@ class ServiceStore(object):
     def clear_services(self, request=None):
         """
         Removes all OWS services from storage.
+        """
+        raise NotImplementedError
+
+
+class JobStore(object):
+    """
+    Storage for job tracking.
+    """
+
+    def save_job(self, task_id, process, service=None, is_workflow=False, user_id=None, async=True):
+        """
+        Stores a job in storage.
+        """
+        raise NotImplementedError
+
+    def update_job(self, job, attributes):
+        """
+        Updates a job parameters in mongodb storage.
+        :param job: instance of ``twitcher.datatype.Job``.
+        :param attributes: dictionary of field:value to update.
+        """
+        raise NotImplementedError
+
+    def delete_job(self, name, request=None):
+        """
+        Removes job from database.
+        """
+        raise NotImplementedError
+
+    def fetch_by_id(self, job_id, request=None):
+        """
+        Get job for given ``job_id`` from storage.
+        """
+        raise NotImplementedError
+
+    def list_jobs(self, request=None):
+        """
+        Lists all jobs in database.
+        """
+        raise NotImplementedError
+
+    def find_jobs(self, request, page=0, limit=10, process=None, service=None,
+                  tag=None, access=None, status=None, sort=None):
+        """
+        Finds all jobs in database matching search filters.
+        """
+        raise NotImplementedError
+
+    def clear_jobs(self, request=None):
+        """
+        Removes all jobs from storage.
         """
         raise NotImplementedError

--- a/twitcher/store/memory.py
+++ b/twitcher/store/memory.py
@@ -39,8 +39,7 @@ class MemoryTokenStore(AccessTokenStore):
 
 from twitcher.store.base import ServiceStore
 from twitcher.datatype import Service
-from twitcher.exceptions import ServiceRegistrationError
-from twitcher.exceptions import ServiceNotFound
+from twitcher.exceptions import ServiceRegistrationError, ServiceNotFound
 from twitcher import namesgenerator
 from twitcher.utils import baseurl
 
@@ -139,3 +138,58 @@ class MemoryServiceStore(ServiceStore):
         self.url_index = {}
         self.name_index = {}
         return True
+
+
+from twitcher.store.base import JobStore
+from twitcher.datatype import Job
+from twitcher.exceptions import JobRegistrationError, JobNotFound
+
+
+class MemoryJobStore(JobStore):
+    """
+    Stores job tracking in memory. Useful for testing purposes.
+    """
+    def save_job(self, task_id, process, service=None, is_workflow=False, user_id=None, async=True):
+        """
+        Stores a job in memory.
+        """
+        raise NotImplementedError
+
+    def update_job(self, job, attributes):
+        """
+        Updates a job parameters in mongodb storage.
+        :param job: instance of ``twitcher.datatype.Job``.
+        :param attributes: dictionary of field:value to update.
+        """
+        raise NotImplementedError
+
+    def delete_job(self, job_id, request=None):
+        """
+        Removes job from memory.
+        """
+        raise NotImplementedError
+
+    def fetch_by_id(self, job_id, request=None):
+        """
+        Gets job for given ``job_id`` from memory.
+        """
+        raise NotImplementedError
+
+    def list_jobs(self, request=None):
+        """
+        Lists all jobs in memory.
+        """
+        raise NotImplementedError
+
+    def find_jobs(self, request, page=0, limit=10, process=None, service=None,
+                  tag=None, access=None, status=None, sort=None):
+        """
+        Finds all jobs in memory matching search filters.
+        """
+        raise NotImplementedError
+
+    def clear_jobs(self, request=None):
+        """
+        Removes all jobs from memory.
+        """
+        raise NotImplementedError

--- a/twitcher/wps_restapi/jobs/jobs.py
+++ b/twitcher/wps_restapi/jobs/jobs.py
@@ -1,17 +1,14 @@
 from pyramid.httpexceptions import *
-from pyramid.security import authenticated_userid
 from pyramid_celery import celery_app as app
-from datetime import datetime
-from twitcher.db import MongoDB
+from twitcher.adapter import jobstore_factory
+from twitcher.exceptions import JobNotFound
 from twitcher.wps_restapi import swagger_definitions as sd
 from twitcher.wps_restapi.utils import wps_restapi_base_url
 from twitcher.wps_restapi.status import *
 from twitcher.wps_restapi.sort import *
-from pymongo import ASCENDING, DESCENDING
 from owslib.wps import WPSExecution
 from lxml import etree
 from celery.utils.log import get_task_logger
-import uuid
 import requests
 
 logger = get_task_logger(__name__)
@@ -23,42 +20,6 @@ def job_url(request, job):
         provider_id=job['provider_id'],
         process_id=job['process_id'],
         job_id=job['task_id'])
-
-
-def add_job(db, task_id, process_id, provider_id, title=None, abstract=None,
-            service_name=None, service=None, status_location=None,
-            is_workflow=False, caption=None, userid=None,
-            async=True):
-    tags = ['dev']
-    if is_workflow:
-        tags.append('workflow')
-    else:
-        tags.append('single')
-    if async:
-        tags.append('async')
-    else:
-        tags.append('sync')
-    job = dict(
-        identifier=uuid.uuid4().get_hex(),
-        task_id=task_id,                    # TODO: why not using as identifier?
-        userid=userid,
-        is_workflow=is_workflow,
-        service_name=service_name,          # wps service name (service identifier)
-        service=service or service_name,    # wps service title (url, service_name or service title)
-        process_id=process_id,              # process identifier
-        provider_id=provider_id,            # process identifier
-        title=title or process_id,          # process title (identifier or title)
-        abstract=abstract or "No Summary",
-        status_location=status_location,
-        created=datetime.now(),
-        tags=tags,
-        caption=caption,
-        status=STATUS_ACCEPTED,
-        response=None,
-        request=None,
-    )
-    db.jobs.insert(job)
-    return job
 
 
 def check_status(url=None, response=None, sleep_secs=2, verify=False):
@@ -88,71 +49,26 @@ def check_status(url=None, response=None, sleep_secs=2, verify=False):
     return execution
 
 
-def filter_jobs(collection, request, page=0, limit=10, process=None,
-                provider=None, tag=None, access=None, status=None, sort=SORT_CREATED):
-    search_filter = {}
-    if access == 'public':
-        search_filter['tags'] = 'public'
-    elif access == 'private':
-        search_filter['tags'] = {'$ne': 'public'}
-        search_filter['userid'] = authenticated_userid(request)
-    elif access == 'all' and request.has_permission('admin'):
-        pass
-    else:
-        if tag is not None:
-            search_filter['tags'] = tag
-        search_filter['userid'] = authenticated_userid(request)
-
-    if status in status_categories.keys():
-        search_filter['status'] = {'$in': status_categories[status]}
-    elif status:
-        search_filter['status'] = status
-
-    if process is not None:
-        search_filter['process_id'] = process
-
-    if provider is not None:
-        search_filter['provider_id'] = provider
-
-    count = collection.find(search_filter).count()
-    if sort == SORT_USER:
-        sort = 'userid'
-    elif sort == SORT_PROCESS:
-        sort = SORT_TITLE
-
-    sort_order = DESCENDING if sort == SORT_FINISHED or sort == SORT_CREATED else ASCENDING
-    sort_criteria = [(sort, sort_order)]
-    items = list(collection.find(search_filter).skip(page * limit).limit(limit).sort(sort_criteria))
-    return items, count
-
-
 def get_job(request):
     """
     :returns: Job information if found.
     :raises: HTTPNotFound with JSON body details on missing/non-matching job, process, provider IDs.
     """
     job_id = request.matchdict.get('job_id')
-
-    db = MongoDB.get(request.registry)
-    collection = db.jobs
-    job = collection.find_one({'task_id': job_id})
-
-    if not job:
-        raise HTTPNotFound('Could not find specified `job_id`.')
+    store = jobstore_factory(request.registry)
+    try:
+        job = store.fetch_by_id(job_id)
+    except JobNotFound:
+        raise HTTPNotFound('Could not find job with specified `job_id`')
 
     provider_id = request.matchdict.get('provider_id', job['provider_id'])
     process_id = request.matchdict.get('process_id', job['process_id'])
 
     if job['provider_id'] != provider_id:
-        raise HTTPNotFound('Could not find specified `provider_id`.')
+        raise HTTPNotFound('Could not find job with specified `provider_id`.')
     if job['process_id'] != process_id:
-        raise HTTPNotFound('Could not find specified `process_id`.')
+        raise HTTPNotFound('Could not find job with specified `process_id`.')
     return job
-
-
-def get_filtered_jobs(request, **filter_kwargs):
-    db = MongoDB.get(request.registry)
-    return filter_jobs(db.jobs, request, **filter_kwargs)
 
 
 @sd.jobs_full_service.get(tags=[sd.jobs_tag, sd.providers_tag], renderer='json',
@@ -177,7 +93,8 @@ def get_jobs(request):
         'process': request.params.get('process', None) or request.matchdict.get('process_id', None),
         'provider': request.params.get('provider', None) or request.matchdict.get('provider_id', None),
     }
-    items, count = get_filtered_jobs(request, **filters)
+    store = jobstore_factory(request.registry)
+    items, count = store.find_jobs(request, **filters)
     return HTTPOk(json={
         'count': count,
         'page': page,

--- a/twitcher/wps_restapi/sort.py
+++ b/twitcher/wps_restapi/sort.py
@@ -2,16 +2,14 @@ SORT_CREATED = 'created'
 SORT_FINISHED = 'finished'
 SORT_STATUS = 'status'
 SORT_PROCESS = 'process'
-SORT_PROVIDER = 'provider'
+SORT_SERVICE = 'service'
 SORT_USER = 'user'
-SORT_TITLE = 'title'
 
 sort_values = frozenset([
     SORT_CREATED,
     SORT_FINISHED,
     SORT_STATUS,
     SORT_PROCESS,
-    SORT_PROVIDER,
+    SORT_SERVICE,
     SORT_USER,
-    SORT_TITLE,
 ])


### PR DESCRIPTION
# DONE:

- adds `twitcher.db_factory` setting that allows to switch between db factory implementations
  - removes the need for `database` input everywhere in the code
  - easy modification for tests, just need to specify `twitcher.db_factory = 'memory'` (or any other implementation) to switch everywhere in the TestApp

- adds `jobstore_factory`, `JobStore` and mongodb `Job` items.
  - allow the use for store factories like already employed for services, accestoken
  - remove direct dependency to mongodb in the job's functions
 
- removed many redundant fields in jobs 
  - `service`/`service_name`/`provider`/`provider_id` => `service`
  - `process`/`process_id` => `process`
  - all fields already available via `DescribeProcess`, which can be called using the  `service` and `process` information

# TODO:

- [ ] validate process job registration/update to db and execution