### PR TITLE
requests file adapter

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ pyramid_mako
 webob
 requests
 requests_oauthlib
+requests_file
 pymongo
 argcomplete
 celery

--- a/twitcher/wps_restapi/jobs/jobs.py
+++ b/twitcher/wps_restapi/jobs/jobs.py
@@ -13,6 +13,7 @@ from lxml import etree
 from celery.utils.log import get_task_logger
 import uuid
 import requests
+from requests_file import FileAdapter
 
 logger = get_task_logger(__name__)
 
@@ -74,7 +75,9 @@ def check_status(url=None, response=None, sleep_secs=2, verify=False):
         xml = response
     elif url:
         logger.debug('using status_location url ...')
-        xml = requests.get(url, verify=verify).content
+        request_session = requests.Session()
+        request_session.mount('file://', FileAdapter())
+        xml = request_session.get(url, verify=verify).content
     else:
         raise Exception("you need to provide a status-location url or response object.")
     if type(xml) is unicode:


### PR DESCRIPTION
- add requests adapter for `file://` responses returned by tmp job output
- required to allow monitoring jobs and returning job output results