### PR TITLE
default adapter if imported doesn't implement store factory

### DIFF
--- a/twitcher/adapter/__init__.py
+++ b/twitcher/adapter/__init__.py
@@ -38,7 +38,7 @@ def adapter_factory(settings):
 def get_adapter_store_factory(adapter, store_name, registry):
     try:
         store = getattr(adapter, store_name)
-    except AttributeError:
+    except NotImplementedError:
         LOGGER.warn("Adapter `{0!r}` doesn't implement `{1!r}`, falling back to `DefaultAdapter` implementation."
                     .format(adapter, store_name))
         adapter = DefaultAdapter()

--- a/twitcher/adapter/__init__.py
+++ b/twitcher/adapter/__init__.py
@@ -35,25 +35,36 @@ def adapter_factory(settings):
     return DefaultAdapter()
 
 
-def servicestore_factory(registry):
+def get_adapter_store_factory(adapter, store_name, registry):
     try:
-        return adapter_factory(registry.settings).servicestore_factory(registry)
+        store = getattr(adapter, store_name)
+    except AttributeError:
+        LOGGER.warn("Adapter `{0!r}` doesn't implement `{1!r}`, falling back to `DefaultAdapter` implementation."
+                    .format(adapter, store_name))
+        adapter = DefaultAdapter()
+        store = getattr(adapter, store_name)
     except Exception as e:
-        LOGGER.error('Adapter raised an exception while getting servicestore_factory : {!r}'.format(e))
+        LOGGER.error("Adapter `{0!r}` raised an exception while getting `{1!r}` : `{2!r}`"
+                     .format(adapter, store_name, e))
         raise
+    try:
+        return store(registry)
+    except Exception as e:
+        LOGGER.error("Adapter `{0!r}` raised an exception while instantiating `{1!r}` : {2!r}"
+                     .format(adapter, store_name, e))
+        raise
+
+
+def servicestore_factory(registry):
+    adapter = adapter_factory(registry.settings)
+    return get_adapter_store_factory(adapter, 'servicestore_factory', registry)
 
 
 def jobstore_factory(registry):
-    try:
-        return adapter_factory(registry.settings).jobstore_factory(registry)
-    except Exception as e:
-        LOGGER.error('Adapter raised an exception while getting jobstore_factory : {!r}'.format(e))
-        raise
+    adapter = adapter_factory(registry.settings)
+    return get_adapter_store_factory(adapter, 'jobstore_factory', registry)
 
 
 def owssecurity_factory(registry):
-    try:
-        return adapter_factory(registry.settings).owssecurity_factory(registry)
-    except Exception as e:
-        LOGGER.error('Adapter raised an exception while getting owssecurity_factory : {!r}'.format(e))
-        raise
+    adapter = adapter_factory(registry.settings)
+    return get_adapter_store_factory(adapter, 'owssecurity_factory', registry)


### PR DESCRIPTION
Allow defaulting back to `DefaultAdapter` if imported one doesn't implement a specific store factory.
Removes the need for external adapters to implement every store by calling  and returning the `DefaultAdapter`themselves.