### PR TITLE
Jobs improvement

### DIFF
--- a/twitcher/__init__.py
+++ b/twitcher/__init__.py
@@ -1,4 +1,4 @@
-__version__ = 'pavics-0.3.16'
+__version__ = 'pavics-0.3.17'
 
 import os
 import sys

--- a/twitcher/wps_restapi/jobs/jobs.py
+++ b/twitcher/wps_restapi/jobs/jobs.py
@@ -30,7 +30,8 @@ def job_format_json(request, job):
         "progress": job.progress
     }
     if job.status in status.status_categories[status.STATUS_FINISHED]:
-        if job.status == status.STATUS_SUCCEEDED:
+        # back compatibility: check also finished jobs that should have succeeded status
+        if job.status in [status.STATUS_SUCCEEDED, status.STATUS_FINISHED]:
             resource = 'results'
         else:
             resource = 'exceptions'

--- a/twitcher/wps_restapi/jobs/jobs.py
+++ b/twitcher/wps_restapi/jobs/jobs.py
@@ -120,7 +120,7 @@ def get_jobs(request):
         'count': count,
         'page': page,
         'limit': limit,
-        'jobs': [job.task_id if detail else job_format_json(request, job) for job in items]
+        'jobs': [job_format_json(request, job) if detail else job.task_id for job in items]
     })
 
 

--- a/twitcher/wps_restapi/jobs/jobs.py
+++ b/twitcher/wps_restapi/jobs/jobs.py
@@ -25,19 +25,21 @@ def job_url(request, job):
 
 def job_format_json(request, job):
     job_json = {
+        "id": job.task_id,
         "status": job.status,
         "message": job.status_message,
         "progress": job.progress
     }
-    if job.status in status.status_categories[status.STATUS_FINISHED]:
-        # back compatibility: check also finished jobs that should have succeeded status
+    # back compatibility: check also finished jobs that should have succeeded status
+    job_finished = list(status.status_categories[status.STATUS_FINISHED]) + list([status.STATUS_FINISHED])
+    if job.status in job_finished:
         if job.status in [status.STATUS_SUCCEEDED, status.STATUS_FINISHED]:
             resource = 'results'
         else:
             resource = 'exceptions'
 
         job_json[resource] = '{job_url}/{resource}'.format(job_url=job_url(request, job), resource=resource.lower())
-        job_json['logs'] = '{job_url}/logs'.format(job_url=job_url(request, job))
+    job_json['logs'] = '{job_url}/logs'.format(job_url=job_url(request, job))
     return job_json
 
 

--- a/twitcher/wps_restapi/swagger_definitions.py
+++ b/twitcher/wps_restapi/swagger_definitions.py
@@ -417,6 +417,7 @@ JobSortEnum = SchemaNode(
 
 
 class GetJobsQueries(MappingSchema):
+    detail = SchemaNode(Boolean(), description="Provide job details instead of IDs.", default=False, example=True)
     page = SchemaNode(Integer(), missing=drop, default=0)
     limit = SchemaNode(Integer(), missing=drop, default=10)
     status = JobStatusEnum


### PR DESCRIPTION
Adds `detail=true/false` param for unwrapping job details instead of IDs in `GET /jobs` and `GET /providers/{id}/processes/{id}/jobs` requests.

JSON formatting already handled by job runner.

Resolves Ouranosinc/pavics-sdi#89